### PR TITLE
Ensure git history is available for snap version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
       snap: ${{ steps.build.outputs.snap }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for version determination
       - uses: snapcore/action-build@v1
         id: build
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Snap version is generated by the python setup.py
from git via setuptools_scm.
This requires the full git history to be available so it can find the latest tags correctly.
actions/checkout@v4 by default only fetches a single revision, so we need to tell it to fetch all history by setting fetch-depth to 0.