### PR TITLE
fix snap versioning

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,10 @@ parts:
     source: .
     plugin: python
     python-requirements: [./requirements.txt]
+    build-packages: # required for finding version
+      - python3-setuptools-scm
     override-build: |
-      snapcraftctl build
-      echo "Version: $(python3 setup.py --version)"
-      snapcraftctl set-version "$(python3 setup.py --version)"
+      VERSION="$(python3 -m setuptools_scm)"
+      echo "Version: $VERSION"
+      craftctl default
+      craftctl set version="$VERSION"


### PR DESCRIPTION
Fix the [versioning issue](https://github.com/canonical/prometheus-juju-backup-all-exporter/actions/runs/25950415071/job/76287086795#step:3:189) in snap packing caused by the deprecation of `setup.py`